### PR TITLE
Extend compatibility to wagtail<2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,10 @@ that shows both Page and Document results.
 from itertools import chain
 
 from wagtail.core.models import Page
-from wagtail.documents.models import get_document_model
+try:
+    from wagtail.documents.models import get_document_model # wagtail < 2.8
+except ImportError:
+    from wagtail.documents import get_document_model # wagtail >= 2.8
 
 
 def search(request):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ except ImportError:
 
 
 install_requires = [
-    "wagtail>=2,<2.6",
+    "wagtail>=2,<2.12",
     "textract",
 ]
 

--- a/src/wagtail_textract/management/commands/transcribe_documents.py
+++ b/src/wagtail_textract/management/commands/transcribe_documents.py
@@ -1,6 +1,9 @@
 from django.core.management.base import BaseCommand
 
-from wagtail.documents.models import get_document_model
+try:
+    from wagtail.documents.models import get_document_model # wagtail < 2.8
+except ImportError:
+    from wagtail.documents import get_document_model # wagtail >= 2.8
 
 from wagtail_textract.handlers import async_transcribe_document
 

--- a/src/wagtail_textract/tests/settings.py
+++ b/src/wagtail_textract/tests/settings.py
@@ -2,4 +2,7 @@ from wagtail.tests.settings import *
 
 MEDIA_ROOT = '.'
 WAGTAILDOCS_DOCUMENT_MODEL = 'wagtail_textract.document'
-INSTALLED_APPS = INSTALLED_APPS + ('wagtail_textract',)
+if type(INSTALLED_APPS) is list:
+    INSTALLED_APPS = INSTALLED_APPS + ['wagtail_textract',]
+else:
+    INSTALLED_APPS = INSTALLED_APPS + ('wagtail_textract',)

--- a/src/wagtail_textract/tests/test_document_class.py
+++ b/src/wagtail_textract/tests/test_document_class.py
@@ -1,4 +1,7 @@
-from wagtail.documents.models import get_document_model
+try:
+    from wagtail.documents.models import get_document_model # wagtail < 2.8
+except ImportError:
+    from wagtail.documents import get_document_model # wagtail >= 2.8
 
 
 def test_document_class():

--- a/src/wagtail_textract/tests/test_management_command.py
+++ b/src/wagtail_textract/tests/test_management_command.py
@@ -3,7 +3,10 @@ import time
 
 from django.core.files import File
 from django.core.management import call_command
-from wagtail.documents.models import get_document_model
+try:
+    from wagtail.documents.models import get_document_model # wagtail < 2.8
+except ImportError:
+    from wagtail.documents import get_document_model # wagtail >= 2.8
 
 Document = get_document_model()
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,12 @@ envlist =
     py{35,36}-dj{21}-wt{23}
     py{35,36,37}-dj{21}-wt{24}
     py{35,36,37}-dj{22}-wt{25}
+    py{35,36,37}-dj{22}-wt{26}
+    py{35,36,37}-dj{22}-wt{27}
+    py{35,36,37}-dj{22}-wt{28}
+    py{35,36,37}-dj{22}-wt{29}
+    py{36,37}-dj{22}-wt{210}
+    py{36,37}-dj{22}-wt{211}
 
 [testenv]
 basepython =
@@ -26,6 +32,12 @@ deps =
     wt23: wagtail>=2.3,<2.4
     wt24: wagtail>=2.4,<2.5
     wt25: wagtail>=2.5,<2.6
+    wt26: wagtail>=2.6,<2.7
+    wt27: wagtail>=2.7,<2.8
+    wt28: wagtail>=2.8,<2.9
+    wt29: wagtail>=2.9,<2.10
+    wt210: wagtail>=2.10,<2.11
+    wt211: wagtail>=2.11,<2.12
 
 whitelist_externals =
     make


### PR DESCRIPTION
Made minor changes to make it compatible with wagtail versions >=2, <2.12.
Based on the release notes  of wagtail: 
[v2.8](https://docs.wagtail.io/en/stable/releases/2.8.html#id2), [v2.9](https://docs.wagtail.io/en/stable/releases/2.9.html#id2), [v2.10](https://docs.wagtail.io/en/stable/releases/2.10.html#id2), [2.11](https://docs.wagtail.io/en/stable/releases/2.11.html#id2), it seems like the only change required  is the import of [get_document_model](https://docs.wagtail.io/en/stable/releases/2.8.html#wagtail-documents-models-get-document-model-has-moved).